### PR TITLE
generic pipelines to aid in registering multiple pipelines in IoC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+﻿################################################################################
+# This .gitignore file was automatically created by Microsoft(R) Visual Studio.
+################################################################################
+
+/**/bin
+/**/obj
+/src/packages
+/src/.vs
+*.user

--- a/src/En.Gen.Crankshaft.Tests/PipelineBuilderTests.cs
+++ b/src/En.Gen.Crankshaft.Tests/PipelineBuilderTests.cs
@@ -47,6 +47,42 @@ namespace En.Gen.Crankshaft.Tests
         }
 
         [TestMethod]
+        public void BuildGeneric__Given_RegisteredMiddleware__Then_CreatePipeline()
+        {
+            var payload = "TEST";
+
+            var mockMiddleware = Enumerable.Range(0, 3)
+                .Select(i =>
+                {
+                    var mock = new Mock<IMiddleware>();
+                    mock
+                        .Setup(x => x.Process(payload))
+                        .Returns(Task.FromResult(true));
+                    return mock;
+                })
+                .ToArray();
+
+            var index = 0;
+            var mockFactoryResolver = new Mock<IResolveMiddlewareFactory>();
+            mockFactoryResolver
+                .Setup(x => x.ResolveFactory<IMiddleware>())
+                .Returns(() => mockMiddleware[index++].Object);
+
+            var subject = new PipelineBuilder<string>(mockFactoryResolver.Object);
+            subject
+                .Use<IMiddleware>()
+                .Use<IMiddleware>()
+                .Use<IMiddleware>();
+            var pipeline = subject.Build();
+            pipeline.Process(payload);
+
+            foreach (var mock in mockMiddleware)
+            {
+                mock.Verify(x => x.Process(payload), Times.Once);
+            }
+        }
+
+        [TestMethod]
         public async Task Fork__Given_RegisteredForkedMiddleware__Then_ConfigureForksAndAddForkMiddleware()
         {
             var payload = new object();
@@ -70,6 +106,46 @@ namespace En.Gen.Crankshaft.Tests
             var mockConfigureRight = new Action<IBuildPipeline>(builder => rightBuilderConfigured = true);
 
             var subject = new PipelineBuilder(mockFactoryResolver.Object);
+            var forkResult = subject.Fork<ForkedMiddleware>(mockConfigureLeft, mockConfigureRight);
+
+            Assert.AreSame(subject, forkResult);
+
+            Assert.IsTrue(leftBuilderConfigured);
+            Assert.IsTrue(rightBuilderConfigured);
+
+            var processResult = await subject
+                .Build()
+                .Process(payload);
+
+            Assert.IsTrue(processResult);
+            Assert.IsNotNull(mockForkedMiddleware);
+            mockForkedMiddleware.Verify(x => x.Process(payload), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task ForkGeneric__Given_RegisteredForkedMiddleware__Then_ConfigureForksAndAddForkMiddleware()
+        {
+            var payload = "TEST";
+
+            Mock<ForkedMiddleware> mockForkedMiddleware = null;
+            var mockFactoryResolver = new Mock<IResolveMiddlewareFactory>();
+            mockFactoryResolver
+                .Setup(x => x.ResolveForkFactory<ForkedMiddleware>())
+                .Returns((left, right) =>
+                {
+                    mockForkedMiddleware = new Mock<ForkedMiddleware>(Tuple.Create(left, right));
+                    mockForkedMiddleware
+                        .Setup(x => x.Process(payload))
+                        .Returns(Task.FromResult(true));
+                    return mockForkedMiddleware.Object;
+                });
+
+            var leftBuilderConfigured = false;
+            var rightBuilderConfigured = false;
+            var mockConfigureLeft = new Action<IBuildPipeline>(builder => leftBuilderConfigured = true);
+            var mockConfigureRight = new Action<IBuildPipeline>(builder => rightBuilderConfigured = true);
+
+            var subject = new PipelineBuilder<string>(mockFactoryResolver.Object);
             var forkResult = subject.Fork<ForkedMiddleware>(mockConfigureLeft, mockConfigureRight);
 
             Assert.AreSame(subject, forkResult);

--- a/src/En.Gen.Crankshaft.Tests/PipelineBuilderTests.cs
+++ b/src/En.Gen.Crankshaft.Tests/PipelineBuilderTests.cs
@@ -46,6 +46,13 @@ namespace En.Gen.Crankshaft.Tests
         }
 
         [Fact]
+        public void Build__When_MiddlewareUnregistered__Then_ThrowException()
+        {
+            var subject = new PipelineBuilder(Mock.Of<IResolveMiddlewareFactory>());
+            Assert.Throws<Exception>(() => subject.Use<IMiddleware>());
+        }
+
+        [Fact]
         public void BuildGeneric__Given_RegisteredMiddleware__Then_CreatePipeline()
         {
             var payload = "TEST";

--- a/src/En.Gen.Crankshaft.Tests/PipelineTests.cs
+++ b/src/En.Gen.Crankshaft.Tests/PipelineTests.cs
@@ -21,6 +21,7 @@ namespace En.Gen.Crankshaft.Tests
 
             Assert.True(result);
         }
+
         [Fact]
         public async Task ProcessGeneric__Given_NoMiddleware__Then_DoNotProcess()
         {
@@ -48,11 +49,10 @@ namespace En.Gen.Crankshaft.Tests
 
             var subject = new Pipeline(middleware);
             var result = await subject.Process(payload);
-
+            
             Assert.True(result);
             mockMiddleware.Verify(x => x.Process(payload), Times.Once);
         }
-
 
         [Fact]
         public async Task ProcessGeneric__Given_SingleMiddleware__Then_ProcessPayload()

--- a/src/En.Gen.Crankshaft.Tests/PipelineTests.cs
+++ b/src/En.Gen.Crankshaft.Tests/PipelineTests.cs
@@ -22,6 +22,18 @@ namespace En.Gen.Crankshaft.Tests
 
             Assert.IsTrue(result);
         }
+        [TestMethod]
+        public async Task ProcessGeneric__Given_NoMiddleware__Then_DoNotProcess()
+        {
+            var payload = new object();
+
+            var middleware = new List<Func<IMiddleware>>();
+
+            var subject = new Pipeline<string>(middleware);
+            var result = await subject.Process(payload);
+
+            Assert.IsTrue(result);
+        }
 
         [TestMethod]
         public async Task Process__Given_SingleMiddleware__Then_ProcessPayload()
@@ -36,6 +48,26 @@ namespace En.Gen.Crankshaft.Tests
             var middleware = new List<Func<IMiddleware>> {() => mockMiddleware.Object};
 
             var subject = new Pipeline(middleware);
+            var result = await subject.Process(payload);
+
+            Assert.IsTrue(result);
+            mockMiddleware.Verify(x => x.Process(payload), Times.Once);
+        }
+
+
+        [TestMethod]
+        public async Task ProcessGeneric__Given_SingleMiddleware__Then_ProcessPayload()
+        {
+            var payload = new object();
+
+            var mockMiddleware = new Mock<IMiddleware>();
+            mockMiddleware
+                .Setup(x => x.Process(payload))
+                .Returns(Task.FromResult(true));
+
+            var middleware = new List<Func<IMiddleware>> { () => mockMiddleware.Object };
+
+            var subject = new Pipeline<string>(middleware);
             var result = await subject.Process(payload);
 
             Assert.IsTrue(result);
@@ -62,6 +94,25 @@ namespace En.Gen.Crankshaft.Tests
         }
 
         [TestMethod]
+        public async Task ProcessGeneric__Given_SingleMiddleware__When_ProcessSuccess__Then_PostProcessPayload()
+        {
+            var payload = new object();
+
+            var mockMiddleware = new Mock<IMiddleware>();
+            mockMiddleware
+                .Setup(x => x.Process(payload))
+                .Returns(Task.FromResult(true));
+
+            var middleware = new List<Func<IMiddleware>> { () => mockMiddleware.Object };
+
+            var subject = new Pipeline<string>(middleware);
+            var result = await subject.Process(payload);
+
+            Assert.IsTrue(result);
+            mockMiddleware.Verify(x => x.PostProcess(payload), Times.Once);
+        }
+
+        [TestMethod]
         public async Task Process__Given_SingleMiddleware__When_ProcessFail__Then_DoNotPostProcess()
         {
             var payload = new object();
@@ -74,6 +125,25 @@ namespace En.Gen.Crankshaft.Tests
             var middleware = new List<Func<IMiddleware>> { () => mockMiddleware.Object };
 
             var subject = new Pipeline(middleware);
+            var result = await subject.Process(payload);
+
+            Assert.IsFalse(result);
+            mockMiddleware.Verify(x => x.PostProcess(payload), Times.Never);
+        }
+
+        [TestMethod]
+        public async Task ProcessGeneric__Given_SingleMiddleware__When_ProcessFail__Then_DoNotPostProcess()
+        {
+            var payload = new object();
+
+            var mockMiddleware = new Mock<IMiddleware>();
+            mockMiddleware
+                .Setup(x => x.Process(payload))
+                .Returns(Task.FromResult(false));
+
+            var middleware = new List<Func<IMiddleware>> { () => mockMiddleware.Object };
+
+            var subject = new Pipeline<string>(middleware);
             var result = await subject.Process(payload);
 
             Assert.IsFalse(result);
@@ -118,6 +188,43 @@ namespace En.Gen.Crankshaft.Tests
         }
 
         [TestMethod]
+        public async Task ProcessGeneric__Given_MultipleMiddleware__When__AllSuccess__Then_AllMiddlewareProcessPayload_And_AllMiddlewarePostProcessPayload()
+        {
+            var payload = new object();
+
+            var callOrder = new List<int>();
+
+            var mockMiddlewares = Enumerable.Range(0, 3)
+                .Select(x =>
+                {
+                    var mockMiddleware = new Mock<IMiddleware>();
+                    mockMiddleware
+                        .Setup(mock => mock.Process(payload))
+                        .Returns(Task.FromResult(true))
+                        .Callback(() => callOrder.Add(x));
+                    return mockMiddleware;
+                })
+                .ToArray();
+
+            var middlewares = mockMiddlewares
+                .Select<Mock<IMiddleware>, Func<IMiddleware>>(x => () => x.Object)
+                .ToList();
+
+            var subject = new Pipeline<string>(middlewares);
+            var result = await subject.Process(payload);
+
+            Assert.IsTrue(result);
+            CollectionAssert.AreEqual(new[] { 0, 1, 2 }, callOrder);
+
+            foreach (var mockMiddleware in mockMiddlewares)
+            {
+                mockMiddleware.Verify(x => x.Process(payload), Times.Once);
+                mockMiddleware.Verify(x => x.Process(payload), Times.Once);
+                mockMiddleware.Verify(x => x.PostProcess(payload), Times.Once);
+            }
+        }
+
+        [TestMethod]
         public async Task Process__Given_MultipleMiddleware__When__SecondProcessFails__Then_ShortCircuit()
         {
             var payload = new object();
@@ -138,6 +245,41 @@ namespace En.Gen.Crankshaft.Tests
             };
 
             var subject = new Pipeline(middleware);
+            var result = await subject.Process(payload);
+
+            Assert.IsFalse(result);
+
+            mockFirstMiddleware.Verify(x => x.Process(payload), Times.Once);
+            mockFirstMiddleware.Verify(x => x.PostProcess(payload), Times.Once);
+
+            mockSecondMiddleware.Verify(x => x.Process(payload), Times.Once);
+            mockSecondMiddleware.Verify(x => x.PostProcess(payload), Times.Never);
+
+            mockThirdMiddleware.Verify(x => x.Process(payload), Times.Never);
+            mockThirdMiddleware.Verify(x => x.PostProcess(payload), Times.Never);
+        }
+
+        [TestMethod]
+        public async Task ProcessGeneric__Given_MultipleMiddleware__When__SecondProcessFails__Then_ShortCircuit()
+        {
+            var payload = new object();
+
+            var mockFirstMiddleware = new Mock<IMiddleware>();
+            mockFirstMiddleware
+                .Setup(x => x.Process(payload))
+                .Returns(Task.FromResult(true));
+
+            var mockSecondMiddleware = new Mock<IMiddleware>();
+            var mockThirdMiddleware = new Mock<IMiddleware>();
+
+            var middleware = new List<Func<IMiddleware>>
+            {
+                () => mockFirstMiddleware.Object,
+                () => mockSecondMiddleware.Object,
+                () => mockThirdMiddleware.Object
+            };
+
+            var subject = new Pipeline<string>(middleware);
             var result = await subject.Process(payload);
 
             Assert.IsFalse(result);

--- a/src/En.Gen.Crankshaft/IBuildPipeline.cs
+++ b/src/En.Gen.Crankshaft/IBuildPipeline.cs
@@ -13,4 +13,15 @@ namespace En.Gen.Crankshaft
 
         IPipeline Build();
     }
+
+    public interface IBuildPipeline<in TPayload> : IBuildPipeline
+    {
+        new IBuildPipeline<TPayload> Use<TMiddleware>()
+            where TMiddleware : IMiddleware;
+
+        new IBuildPipeline<TPayload> Fork<TForkedMiddleware>(Action<IBuildPipeline> buildLeft, Action<IBuildPipeline> buildRight)
+            where TForkedMiddleware : ForkedMiddleware;
+
+        new IPipeline<TPayload> Build();
+    }
 }

--- a/src/En.Gen.Crankshaft/IPipeline.cs
+++ b/src/En.Gen.Crankshaft/IPipeline.cs
@@ -1,9 +1,13 @@
+using System;
 using System.Threading.Tasks;
 
 namespace En.Gen.Crankshaft
 {
-    public interface IPipeline
+    public interface IPipeline<in TPayload>
     {
-        Task<bool> Process(object payload);
+        Task<bool> Process(TPayload payload);
+    }
+    public interface IPipeline : IPipeline<object>
+    {
     }
 }

--- a/src/En.Gen.Crankshaft/Pipeline.cs
+++ b/src/En.Gen.Crankshaft/Pipeline.cs
@@ -36,4 +36,17 @@ namespace En.Gen.Crankshaft
             return success;
         }
     }
+
+    public class Pipeline<TPayload> : Pipeline, IPipeline<TPayload>
+    {
+        public Pipeline(IList<Func<IMiddleware>> middleware) :
+            base(middleware)
+        {
+        }
+
+        public async Task<bool> Process(TPayload payload)
+        {
+            return await base.Process(payload);
+        }
+    }
 }

--- a/src/En.Gen.Crankshaft/PipelineBuilder.cs
+++ b/src/En.Gen.Crankshaft/PipelineBuilder.cs
@@ -51,4 +51,31 @@ namespace En.Gen.Crankshaft
             return new Pipeline(Middleware.ToList());
         }
     }
+
+    public class PipelineBuilder<TPayload> : PipelineBuilder, IBuildPipeline<TPayload>
+    {
+        public PipelineBuilder(IResolveMiddlewareFactory factoryResolver) :
+            base(factoryResolver)
+        {
+        }
+
+        public new IBuildPipeline<TPayload> Use<TMiddleware>()
+            where TMiddleware : IMiddleware
+        {
+            base.Use<TMiddleware>();
+            return this;
+        }
+
+        public new IBuildPipeline<TPayload> Fork<TForkedMiddleware>(Action<IBuildPipeline> buildLeft, Action<IBuildPipeline> buildRight)
+            where TForkedMiddleware : ForkedMiddleware
+        {
+            base.Fork<TForkedMiddleware>(buildLeft, buildRight);
+            return this;
+        }
+
+        public new IPipeline<TPayload> Build()
+        {
+            return new Pipeline<TPayload>(Middleware.ToList());
+        }
+    }
 }


### PR DESCRIPTION
You're welcome @gentilim, generic pipeline implementation!  The generics are only superficial, they don't actually affect any behavior as the payload is treated as an object as soon as it's processed.  This will, however, allow us to register multiple pipelines in IoC by payload type.  And (maybe) this is a stepping stone towards generic middleware.

Generic middleware is a much more complex issue and I would suggest we look at alternatives if we want to go that route.  I played around with it a bit, and I'm not aware of a way to constrain the builder's `.Use<TMiddleware>` with something like

``` csharp
public interface IBuildPipeline<TPipelinePayload>
{
    public IBuildPipeline<TPipelinePayload> Use<TMiddleware>()
        where TMiddleware : IMiddleware<TMiddlewarePayload>
        where TPipelinePayload : TMiddlewarePayload; // <= doesn't compile :(
}
```
