### PR TITLE
moving OpenCover to after test script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@
   build:
     project: src\Crankshaft.sln
     verbosity: minimal
-  test_script:
+  after_test:
   - cmd: >-
       src\packages\OpenCover.4.6.519\tools\OpenCover.Console.exe -register:user -target:src\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe -targetargs:"src\En.Gen.Crankshaft.Tests\bin\debug\En.Gen.Crankshaft.Tests.dll -noshadow -appveyor" -filter:"+[En.Gen.*]* -[*.Tests]*" -output:coverage.xml
 

--- a/src/En.Gen.Crankshaft.Tests/Fork/ForkedMiddlewareTests.cs
+++ b/src/En.Gen.Crankshaft.Tests/Fork/ForkedMiddlewareTests.cs
@@ -30,43 +30,45 @@ namespace En.Gen.Crankshaft.Tests.Fork
         [Fact]
         public async Task Process__Given_LeftAndRightPipeline__When_ChooseLeft__Then_ProcessLeftAndReturnResult()
         {
+            var environment = new Dictionary<string, object>();
             var payload = "LEFT";
 
-            var mockLeftPipeline = new Mock<IPipeline<object>>();
+            var mockLeftPipeline = new Mock<IForkedPipeline>();
             mockLeftPipeline
-                .Setup(x => x.Process(payload))
-                .Returns(Task.FromResult(true));
+                .Setup(x => x.Process(environment, payload))
+                .ReturnsAsync(true);
 
-            var mockRightPipeline = new Mock<IPipeline<object>>();
+            var mockRightPipeline = new Mock<IForkedPipeline>();
 
-            var subject = new TestableForkedMiddleware(Tuple.Create(mockLeftPipeline.Object, mockRightPipeline.Object));
+            var subject = new TestableForkedMiddleware(Tuple.Create<IPipeline<object>, IPipeline<object>>(mockLeftPipeline.Object, mockRightPipeline.Object));
 
-            var result = await subject.BeforeNext(new Dictionary<string, object>(), payload);
+            var result = await subject.BeforeNext(environment, payload);
 
             Assert.True(result);
-            mockLeftPipeline.Verify(x => x.Process(payload), Times.Once);
-            mockRightPipeline.Verify(x => x.Process(It.IsAny<object>()), Times.Never());
+            mockLeftPipeline.Verify(x => x.Process(environment, payload), Times.Once);
+            mockRightPipeline.Verify(x => x.Process(It.IsAny<IDictionary<string, object>>(), It.IsAny<object>()), Times.Never());
         }
 
         [Fact]
         public async Task Process__Given_LeftAndRightPipeline__When_ChooseRight__Then_ProcessRightAndReturnResult()
         {
+            var environment = new Dictionary<string, object>();
             var payload = "RIGHT";
 
-            var mockLeftPipeline = new Mock<IPipeline<object>>();
+            var mockLeftPipeline = new Mock<IForkedPipeline>();
 
-            var mockRightPipeline = new Mock<IPipeline<object>>();
+            var mockRightPipeline = new Mock<IForkedPipeline>();
             mockRightPipeline
-                .Setup(x => x.Process(payload))
-                .Returns(Task.FromResult(false));
+                .Setup(x => x.Process(environment, payload))
+                .ReturnsAsync(true);
 
-            var subject = new TestableForkedMiddleware(Tuple.Create(mockLeftPipeline.Object, mockRightPipeline.Object));
+            var subject = new TestableForkedMiddleware(Tuple.Create<IPipeline<object>, IPipeline<object>>(mockLeftPipeline.Object, mockRightPipeline.Object));
 
-            var result = await subject.BeforeNext(new Dictionary<string, object>(), payload);
+            var result = await subject.BeforeNext(environment, payload);
 
-            Assert.False(result);
-            mockLeftPipeline.Verify(x => x.Process(It.IsAny<object>()), Times.Never);
-            mockRightPipeline.Verify(x => x.Process(payload), Times.Once);
+            Assert.True(result);
+            mockLeftPipeline.Verify(x => x.Process(It.IsAny<IDictionary<string, object>>(), It.IsAny<object>()), Times.Never);
+            mockRightPipeline.Verify(x => x.Process(environment, payload), Times.Once);
         }
         
         [Fact]

--- a/src/En.Gen.Crankshaft/Properties/AssemblyInfo.cs
+++ b/src/En.Gen.Crankshaft/Properties/AssemblyInfo.cs
@@ -1,7 +1,6 @@
 ﻿using System.Resources;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -26,5 +25,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("0.1.0.0")]
+[assembly: AssemblyFileVersion("0.1.0.0")]
+
+// For mocking internal interfaces in tests
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]


### PR DESCRIPTION
may run tests redundantly, but running them wrapped in OpenCover process doesn't seem to be notifying build of test failures
